### PR TITLE
구매 금액을 입력 받기 위한 view 설계

### DIFF
--- a/src/main/java/lotto/MoneyInputView.java
+++ b/src/main/java/lotto/MoneyInputView.java
@@ -6,6 +6,7 @@ public class MoneyInputView {
 
     private String input;
     private int money;
+    private static final int ONE_ISSUE_LOTTO = 1000;
 
     public MoneyInputView() {
         validate();
@@ -15,6 +16,7 @@ public class MoneyInputView {
         input = Console.readLine();
         try {
             nonZero();
+            leastOneIssue();
         } catch (IllegalArgumentException e) {
             System.out.println(e.getMessage());
             validate();
@@ -27,5 +29,11 @@ public class MoneyInputView {
             throw new IllegalArgumentException("[ERROR] 0 이 아닌 숫자를 입력해야 합니다.");
         }
         money = Integer.parseInt(input);
+    }
+
+    private void leastOneIssue() {
+        if (ONE_ISSUE_LOTTO > money) {
+            throw new IllegalArgumentException("[ERROR] 최소한 1000원 이상이어야 합니다.");
+        }
     }
 }

--- a/src/main/java/lotto/MoneyInputView.java
+++ b/src/main/java/lotto/MoneyInputView.java
@@ -7,6 +7,7 @@ public class MoneyInputView {
     private String input;
     private int money;
     private static final int ONE_ISSUE_LOTTO = 1000;
+    private static final int ZERO = 0;
 
     public MoneyInputView() {
         validate();
@@ -17,6 +18,7 @@ public class MoneyInputView {
         try {
             nonZero();
             leastOneIssue();
+            nonRemainder();
         } catch (IllegalArgumentException e) {
             System.out.println(e.getMessage());
             validate();
@@ -34,6 +36,13 @@ public class MoneyInputView {
     private void leastOneIssue() {
         if (ONE_ISSUE_LOTTO > money) {
             throw new IllegalArgumentException("[ERROR] 최소한 1000원 이상이어야 합니다.");
+        }
+    }
+
+    private void nonRemainder() {
+        int remainder = Integer.parseInt(input) % ONE_ISSUE_LOTTO;
+        if (ZERO < remainder) {
+            throw new IllegalArgumentException("[ERROR] 나누어 떨어져야 합니다.");
         }
     }
 }

--- a/src/main/java/lotto/MoneyInputView.java
+++ b/src/main/java/lotto/MoneyInputView.java
@@ -1,0 +1,31 @@
+package lotto;
+
+import camp.nextstep.edu.missionutils.Console;
+
+public class MoneyInputView {
+
+    private String input;
+    private int money;
+
+    public MoneyInputView() {
+        validate();
+    }
+
+    private void validate() {
+        input = Console.readLine();
+        try {
+            nonZero();
+        } catch (IllegalArgumentException e) {
+            System.out.println(e.getMessage());
+            validate();
+        }
+    }
+
+
+    private void nonZero() {
+        if (Integer.parseInt(input) == 0) {
+            throw new IllegalArgumentException("[ERROR] 0 이 아닌 숫자를 입력해야 합니다.");
+        }
+        money = Integer.parseInt(input);
+    }
+}

--- a/src/main/java/lotto/MoneyInputView.java
+++ b/src/main/java/lotto/MoneyInputView.java
@@ -4,10 +4,11 @@ import camp.nextstep.edu.missionutils.Console;
 
 public class MoneyInputView {
 
+    private static final int ZERO = 0;
+    private static final int ONE_ISSUE_LOTTO = 1000;
     private String input;
     private int money;
-    private static final int ONE_ISSUE_LOTTO = 1000;
-    private static final int ZERO = 0;
+    private int issueCount;
 
     public MoneyInputView() {
         validate();
@@ -19,6 +20,7 @@ public class MoneyInputView {
             nonZero();
             leastOneIssue();
             nonRemainder();
+            makeIssueLotto();
         } catch (IllegalArgumentException e) {
             System.out.println(e.getMessage());
             validate();
@@ -44,5 +46,14 @@ public class MoneyInputView {
         if (ZERO < remainder) {
             throw new IllegalArgumentException("[ERROR] 나누어 떨어져야 합니다.");
         }
+    }
+
+
+    private void makeIssueLotto() {
+        issueCount = money / ONE_ISSUE_LOTTO;
+    }
+
+    public int getIssueCount() {
+        return issueCount;
     }
 }

--- a/src/test/java/lotto/MoneyInputViewTest.java
+++ b/src/test/java/lotto/MoneyInputViewTest.java
@@ -1,0 +1,22 @@
+package lotto;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class MoneyInputViewTest {
+
+    @Test
+    void multiple_zero() {
+        String input = "000";
+        if (Integer.parseInt(input) == 0) {
+            System.out.println("0을 간주");
+        }
+    }
+
+    @Test
+    void least_one_lotto() {
+
+    }
+
+}


### PR DESCRIPTION
### 입력 값을 금액으로 천 원 단위 로또를 발행하는 순서
#### 콘솔로 입력받을 때 유효검사 
- 0000 -> 0 어쨋든 숫자임으로 0으로 간주
- 0을 입력받으면 모든 수로 나눠도 0으로 나누어 떨어지지만, 이는 구매 자체가 안되어 예외처리.
- 최소 한 장을 구매할 수 있는 금액 1000원을 가지고 있는지, 그 미만은 경우 예외처리.
- 0이 아닌, 입력값에서 천 원으로 나누어 떨어지지 않는 경우에 예외처리.

#### 이렇게 한다면 1000 배수의 수로만 정상적인 입력으로 간주된다. 그 금액에 비례한 로또 발급.